### PR TITLE
Füge NetworkManager hinzu

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,10 +81,6 @@ The following environment variables are supported:
 
    Password for the first user
 
- * `WPA_ESSID`, `WPA_PASSWORD` and `WPA_COUNTRY` (Default: unset)
-
-   If these are set, they are use to configure `wpa_supplicant.conf`, so that the raspberry pi can automatically connect to a wifi network on first boot.
-
  * `ENABLE_SSH` (Default: `0`)
 
    Setting to `1` will enable ssh server for remote log in. Note that if you are using a common password such as the defaults there is a high risk of attackers taking over you RaspberryPi.

--- a/build.sh
+++ b/build.sh
@@ -155,9 +155,6 @@ export LOG_FILE="${WORK_DIR}/build.log"
 
 export FIRST_USER_NAME=${FIRST_USER_NAME:-pi}
 export FIRST_USER_PASS=${FIRST_USER_PASS:-raspberry}
-export WPA_ESSID
-export WPA_PASSWORD
-export WPA_COUNTRY
 export ENABLE_SSH="${ENABLE_SSH:-0}"
 
 export BASE_DIR

--- a/stage2/02-net-tweaks/00-packages
+++ b/stage2/02-net-tweaks/00-packages
@@ -1,4 +1,3 @@
 wpasupplicant wireless-tools firmware-atheros firmware-brcm80211 firmware-libertas firmware-misc-nonfree firmware-realtek
-raspberrypi-net-mods
 dhcpcd5
 net-tools

--- a/stage2/02-net-tweaks/00-packages
+++ b/stage2/02-net-tweaks/00-packages
@@ -1,3 +1,4 @@
 wpasupplicant wireless-tools firmware-atheros firmware-brcm80211 firmware-libertas firmware-misc-nonfree firmware-realtek
+network-manager
 dhcpcd5
 net-tools

--- a/stage2/02-net-tweaks/01-run.sh
+++ b/stage2/02-net-tweaks/01-run.sh
@@ -2,18 +2,3 @@
 
 install -v -d					"${ROOTFS_DIR}/etc/systemd/system/dhcpcd.service.d"
 install -v -m 644 files/wait.conf		"${ROOTFS_DIR}/etc/systemd/system/dhcpcd.service.d/"
-
-install -v -d					"${ROOTFS_DIR}/etc/wpa_supplicant"
-install -v -m 600 files/wpa_supplicant.conf	"${ROOTFS_DIR}/etc/wpa_supplicant/"
-
-if [ -v WPA_COUNTRY ]
-then
-	echo "country=${WPA_COUNTRY}" >> "${ROOTFS_DIR}/etc/wpa_supplicant/wpa_supplicant.conf"
-fi
-
-if [ -v WPA_ESSID -a -v WPA_PASSWORD ]
-then
-on_chroot <<EOF
-wpa_passphrase ${WPA_ESSID} ${WPA_PASSWORD} >> "/etc/wpa_supplicant/wpa_supplicant.conf"
-EOF
-fi

--- a/stage2/02-net-tweaks/files/wpa_supplicant.conf
+++ b/stage2/02-net-tweaks/files/wpa_supplicant.conf
@@ -1,2 +1,0 @@
-ctrl_interface=DIR=/var/run/wpa_supplicant GROUP=netdev
-update_config=1


### PR DESCRIPTION
NetworkManager soll als Netzwerkdienst verwendet werden. Dazu muss die Datei `wpa_supplicant.conf` entfernt werden, da sie einen Konflikt mit NetworkManager auslöst.

Eine Vorkonfiguration einer WLAN-Verbindung wird hierdurch erstmal nicht mehr ermöglicht.

Das Paket `raspberrypi-net-mods` hat den einzigen Zweck, `wpa_supplicant.conf`aus `/boot` nach `/etc/wpa_supplicant` zu verschieben und muss deswegen entfernt werden.